### PR TITLE
Enhance CI workflow with linting and build steps

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,133 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: ['main', 'develop']
+  pull_request:
+    branches: ['main', 'develop']
+
+env:
+  NODE_ENV: test
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
+  REDIS_URL: redis://localhost:6379
+  JWT_SECRET: test-secret-key-for-ci
+  JWT_EXPIRES_IN: 3600s
+  PORT: 3000
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+jobs:
+  lint-backend:
+    name: Lint Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install backend dependencies
+        run: cd backend && npm ci
+      - name: Generate Prisma Client
+        run: cd backend && npx prisma generate
+      - name: Run ESLint
+        run: cd backend && npx eslint . --ext .ts --max-warnings 0
+        continue-on-error: true
+      - name: Check Prettier
+        run: cd backend && npx prettier --check "src/**/*.ts"
+        continue-on-error: true
+
+  lint-frontend:
+    name: Lint Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+      - name: Run ESLint
+        run: cd frontend && npm run lint
+        continue-on-error: true
+
+  build-backend:
+    name: Build Backend
+    runs-on: ubuntu-latest
+    needs: lint-backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install & Build
+        run: cd backend && npm ci && npm run build
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    needs: lint-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install & Build
+        run: cd frontend && npm ci && npm run build
+
+  test-backend:
+    name: Unit & Integration Tests (Backend)
+    runs-on: ubuntu-latest
+    needs: build-backend
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Install & Test
+        run: cd backend && npm ci && npx prisma migrate deploy && npm run test:cov
+
+  docker-build:
+    name: Docker Build (Backend + Frontend)
+    runs-on: ubuntu-latest
+    needs: [test-backend, build-frontend]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: false
+          tags: travel-planner-backend:latest
+      - name: Build frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: false
+          tags: travel-planner-frontend:latest


### PR DESCRIPTION
Updated CI workflow to support both 'main' and 'develop' branches, added linting and building steps for backend and frontend, and configured database services for testing. closes #22 